### PR TITLE
Adjust home article layout with sidebar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,16 +46,49 @@ export default async function HomePage() {
   const typedPosts = posts.filter((p): p is Record<string, unknown> => isRecord(p));
 
   return (
-    <div className="mx-auto max-w-6xl py-8 sm:py-12 lg:py-16">
-      {typedPosts.length > 0 ? (
-        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-          {typedPosts.map((post, idx) => (
-            <PostCard key={getKey(post, idx)} post={post} />
-          ))}
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12 lg:px-8 lg:py-16">
+      <div className="grid gap-12 lg:grid-cols-3 lg:items-start">
+        <div className="lg:col-span-2">
+          {typedPosts.length > 0 ? (
+            <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
+              {typedPosts.map((post, idx) => (
+                <PostCard key={getKey(post, idx)} post={post} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-neutral-500">まだ記事がありません。</p>
+          )}
         </div>
-      ) : (
-        <p className="text-sm text-neutral-500">まだ記事がありません。</p>
-      )}
+
+        <aside className="space-y-8">
+          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-neutral-900">電子書籍の紹介</h2>
+            <ul className="mt-4 space-y-2 text-sm text-neutral-600">
+              <li>・電子書籍タイトルAの紹介文が入ります。</li>
+              <li>・電子書籍タイトルBの紹介文が入ります。</li>
+            </ul>
+          </section>
+
+          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-neutral-900">カテゴリー一覧</h2>
+            <ul className="mt-4 space-y-2 text-sm text-neutral-600">
+              <li>・カテゴリー1</li>
+              <li>・カテゴリー2</li>
+              <li>・カテゴリー3</li>
+              <li>・カテゴリー4</li>
+            </ul>
+          </section>
+
+          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-neutral-900">人気記事ランキング</h2>
+            <ol className="mt-4 space-y-3 text-sm text-neutral-600">
+              <li>1. 人気記事タイトルサンプル</li>
+              <li>2. 人気記事タイトルサンプル</li>
+              <li>3. 人気記事タイトルサンプル</li>
+            </ol>
+          </section>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -73,14 +73,14 @@ export default function PostCard({ post }: PostCardProps) {
 
   return (
     <article
-      className="group relative flex h-full w-full flex-col overflow-hidden rounded-3xl bg-white shadow-[0_18px_40px_-25px_rgba(15,23,42,0.35)] ring-1 ring-black/5 transition-all duration-300 ease-out hover:-translate-y-2 hover:shadow-[0_28px_60px_-25px_rgba(15,23,42,0.45)]"
+      className="group relative flex h-full w-full flex-col overflow-hidden rounded-3xl bg-white shadow-md shadow-slate-900/5 ring-1 ring-black/5 transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-lg hover:shadow-slate-900/10"
     >
       <Link
         href={href}
         className="flex h-full flex-col focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
       >
-        {/* 画像：常に 16:10 で統一（デフォルト画像も同じ比率） */}
-        <div className="relative aspect-[16/10] w-full overflow-hidden bg-gradient-to-br from-indigo-100 via-white to-purple-50">
+        {/* 画像：常に 4:3 で統一（デフォルト画像も同じ比率） */}
+        <div className="relative aspect-[4/3] w-full overflow-hidden bg-gradient-to-br from-indigo-100 via-white to-purple-50">
           <Image
             src={imgUrl}
             alt={title}


### PR DESCRIPTION
## Summary
- restructure the home page into a responsive two-column layout with a sidebar containing placeholder sections
- ensure the article list remains two cards wide on larger screens while stacking beneath the articles on mobile
- refine post cards with softer shadows, 4:3 imagery emphasis, and a subtle hover lift effect

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cac339ce0c832aa726c5ee23711a7d