### PR TITLE
Update home layout and post card styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,11 +46,11 @@ export default async function HomePage() {
   const typedPosts = posts.filter((p): p is Record<string, unknown> => isRecord(p));
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12 lg:px-8 lg:py-16">
-      <div className="grid gap-12 lg:grid-cols-3 lg:items-start">
-        <div className="lg:col-span-2">
+    <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+      <div className="grid gap-12 lg:grid-cols-[minmax(0,2fr)_minmax(260px,1fr)] lg:items-start">
+        <div className="lg:col-span-1">
           {typedPosts.length > 0 ? (
-            <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-2 md:gap-10">
               {typedPosts.map((post, idx) => (
                 <PostCard key={getKey(post, idx)} post={post} />
               ))}
@@ -60,7 +60,7 @@ export default async function HomePage() {
           )}
         </div>
 
-        <aside className="space-y-8">
+        <aside className="space-y-8 lg:sticky lg:top-28">
           <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
             <h2 className="text-lg font-semibold text-neutral-900">電子書籍の紹介</h2>
             <ul className="mt-4 space-y-2 text-sm text-neutral-600">

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -73,14 +73,14 @@ export default function PostCard({ post }: PostCardProps) {
 
   return (
     <article
-      className="group relative flex h-full w-full flex-col overflow-hidden rounded-3xl bg-white shadow-md shadow-slate-900/5 ring-1 ring-black/5 transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-lg hover:shadow-slate-900/10"
+      className="group relative flex h-full w-full flex-col overflow-hidden rounded-3xl bg-white shadow-sm shadow-slate-900/5 ring-1 ring-black/5 transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-lg hover:shadow-slate-900/10"
     >
       <Link
         href={href}
         className="flex h-full flex-col focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
       >
-        {/* 画像：常に 4:3 で統一（デフォルト画像も同じ比率） */}
-        <div className="relative aspect-[4/3] w-full overflow-hidden bg-gradient-to-br from-indigo-100 via-white to-purple-50">
+        {/* 画像：ワイド比率で統一し、大きめにトリミング */}
+        <div className="relative aspect-[16/10] w-full overflow-hidden bg-gradient-to-br from-indigo-100 via-white to-purple-50">
           <Image
             src={imgUrl}
             alt={title}
@@ -101,12 +101,12 @@ export default function PostCard({ post }: PostCardProps) {
           )}
 
           {/* タイトル */}
-          <h2 className="mt-2 line-clamp-2 text-xl font-bold leading-snug text-gray-900">
+          <h2 className="mt-3 line-clamp-2 text-xl font-bold leading-snug text-gray-900">
             {title}
           </h2>
 
           {/* 日付 */}
-          {date && <time className="mt-1 block text-sm font-medium text-gray-500">{date}</time>}
+          {date && <time className="mt-2 block text-sm font-medium text-gray-500">{date}</time>}
 
           {/* 抜粋（下端に余白を残す） */}
           {excerpt && <p className="mt-4 line-clamp-3 text-sm leading-relaxed text-gray-600">{excerpt}</p>}


### PR DESCRIPTION
## Summary
- center the home page layout within a max-width container and show two post columns on larger screens with a sticky sidebar
- refresh the post card design with wide cover imagery, rounded corners, subtle shadows, and refined spacing

## Testing
- npm run lint

## Preview
- Preview URL: Not available in this environment

------
https://chatgpt.com/codex/tasks/task_e_68cac5e8a708832a9004fd5e4673b8f6