### PR TITLE
Adjust homepage layout and hide hero image

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -109,9 +109,6 @@ export default async function PostPage({
       : null;
   const authorSlug = isRecord(post.author) ? toSlug(post.author?.slug) : "";
 
-  // 16:10 に合わせて生成（CSSでも16:10を担保）
-  const heroUrl = buildImageUrl(post.mainImage, 1200, 750) ?? "/default-og.png";
-
   return (
     <main className="px-4 py-10 max-w-none">
       <article>
@@ -135,23 +132,6 @@ export default async function PostPage({
             ) : null}
           </div>
         </header>
-
-        {/* 見出し画像：中央寄せ・max-w-3xl・16:10（width/height 版で安定） */}
-        <div className="mx-auto max-w-3xl mb-6" style={{ maxWidth: 768 }}>
-          <div className="relative w-full overflow-hidden rounded-xl bg-gray-100">
-            <div className="aspect-[16/10] w-full">
-              <Image
-                src={heroUrl}
-                alt={title}
-                width={1200}
-                height={750}
-                className="block h-auto w-full rounded-xl object-cover"
-                sizes="(max-width: 768px) 100vw, 768px"
-                priority={false}
-              />
-            </div>
-          </div>
-        </div>
 
         {/* 抜粋 */}
         {typeof post.excerpt === "string" && post.excerpt && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,11 +46,11 @@ export default async function HomePage() {
   const typedPosts = posts.filter((p): p is Record<string, unknown> => isRecord(p));
 
   return (
-    <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
-      <div className="grid gap-12 lg:grid-cols-[minmax(0,2fr)_minmax(260px,1fr)] lg:items-start">
+    <div className="mx-auto w-full max-w-[1200px] px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+      <div className="grid gap-12 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] lg:items-start lg:gap-14">
         <div className="lg:col-span-1">
           {typedPosts.length > 0 ? (
-            <div className="grid grid-cols-1 gap-8 md:grid-cols-2 md:gap-10">
+            <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10">
               {typedPosts.map((post, idx) => (
                 <PostCard key={getKey(post, idx)} post={post} />
               ))}
@@ -60,7 +60,7 @@ export default async function HomePage() {
           )}
         </div>
 
-        <aside className="space-y-8 lg:sticky lg:top-28">
+        <aside className="order-last space-y-8 lg:sticky lg:top-28 lg:order-none">
           <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
             <h2 className="text-lg font-semibold text-neutral-900">電子書籍の紹介</h2>
             <ul className="mt-4 space-y-2 text-sm text-neutral-600">

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -6,7 +6,7 @@ export default function SiteFooter() {
 
   return (
     <footer className="mt-20 border-t border-white/60 bg-gradient-to-b from-white to-indigo-50/60">
-      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-[1200px] px-4 py-12 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-3">
             <p className="text-lg font-semibold tracking-tight text-neutral-900">IKEHAYA BLOG</p>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -25,7 +25,7 @@ export default async function SiteHeader() {
 
   return (
     <header className="sticky top-0 z-40 border-b border-white/50 bg-white/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center gap-4 px-4 py-4 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1200px] items-center gap-4 px-4 py-4 sm:px-6 lg:px-8">
         {/* ロゴ */}
         <Link href="/" className="text-xl font-black tracking-tight text-neutral-900 sm:text-2xl">
           IKEHAYA


### PR DESCRIPTION
## Summary
- center the site layout within a 1200px-wide container shared by the header, footer, and homepage content
- update the homepage grid so the post list becomes two columns on large screens with the sidebar pinned to the second column, while stacking cleanly on mobile
- remove the large hero image from article detail pages to show text content first

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cac8e374e4832a86f4ccc58cd4d8d2