### PR TITLE
Adjust home layout for desktop two-column

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,10 +47,10 @@ export default async function HomePage() {
 
   return (
     <div className="mx-auto w-full max-w-[1200px] px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
-      <div className="grid gap-12 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] lg:items-start lg:gap-14">
-        <div className="lg:col-span-1">
+      <div className="flex flex-col gap-12 lg:flex-row lg:items-start lg:gap-14">
+        <div className="lg:min-w-0 lg:flex-1">
           {typedPosts.length > 0 ? (
-            <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10">
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:gap-10">
               {typedPosts.map((post, idx) => (
                 <PostCard key={getKey(post, idx)} post={post} />
               ))}
@@ -60,7 +60,7 @@ export default async function HomePage() {
           )}
         </div>
 
-        <aside className="order-last space-y-8 lg:sticky lg:top-28 lg:order-none">
+        <aside className="order-last space-y-8 lg:order-none lg:sticky lg:top-28 lg:w-[320px] lg:flex-none">
           <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
             <h2 className="text-lg font-semibold text-neutral-900">電子書籍の紹介</h2>
             <ul className="mt-4 space-y-2 text-sm text-neutral-600">


### PR DESCRIPTION
## Summary
- switch the home page layout to a responsive flex row on large screens so the sidebar stays in the right column
- update the post grid to become two columns from the md breakpoint for clearer desktop presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cacaf1536c832aa410bfbaf6de8619