### PR TITLE
Implement responsive home page grid layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,8 +18,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ja">
       <body className="bg-white text-neutral-900 antialiased">
         <SiteHeader />
-        {/* max-w を外し、全幅に変更 → ページ側で自由に制御 */}
-        <main className="min-h-[60vh] px-4 py-8 sm:px-6 lg:px-8">
+        {/* 全ページで最大幅を統一しつつ、内側に余白を確保 */}
+        <main className="mx-auto w-full max-w-[1200px] min-h-[60vh] px-4 py-8 sm:px-6 lg:px-8">
           {children}
         </main>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,49 +46,47 @@ export default async function HomePage() {
   const typedPosts = posts.filter((p): p is Record<string, unknown> => isRecord(p));
 
   return (
-    <div className="mx-auto w-full max-w-[1200px] px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
-      <div className="flex flex-col gap-12 lg:flex-row lg:items-start lg:gap-14">
-        <div className="lg:min-w-0 lg:flex-1">
-          {typedPosts.length > 0 ? (
-            <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:gap-10">
-              {typedPosts.map((post, idx) => (
-                <PostCard key={getKey(post, idx)} post={post} />
-              ))}
-            </div>
-          ) : (
-            <p className="text-sm text-neutral-500">まだ記事がありません。</p>
-          )}
-        </div>
-
-        <aside className="order-last space-y-8 lg:order-none lg:sticky lg:top-28 lg:w-[320px] lg:flex-none">
-          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">電子書籍の紹介</h2>
-            <ul className="mt-4 space-y-2 text-sm text-neutral-600">
-              <li>・電子書籍タイトルAの紹介文が入ります。</li>
-              <li>・電子書籍タイトルBの紹介文が入ります。</li>
-            </ul>
-          </section>
-
-          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">カテゴリー一覧</h2>
-            <ul className="mt-4 space-y-2 text-sm text-neutral-600">
-              <li>・カテゴリー1</li>
-              <li>・カテゴリー2</li>
-              <li>・カテゴリー3</li>
-              <li>・カテゴリー4</li>
-            </ul>
-          </section>
-
-          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">人気記事ランキング</h2>
-            <ol className="mt-4 space-y-3 text-sm text-neutral-600">
-              <li>1. 人気記事タイトルサンプル</li>
-              <li>2. 人気記事タイトルサンプル</li>
-              <li>3. 人気記事タイトルサンプル</li>
-            </ol>
-          </section>
-        </aside>
+    <div className="grid grid-cols-1 gap-12 py-10 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start lg:gap-14 lg:py-14">
+      <div className="lg:min-w-0">
+        {typedPosts.length > 0 ? (
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10">
+            {typedPosts.map((post, idx) => (
+              <PostCard key={getKey(post, idx)} post={post} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-neutral-500">まだ記事がありません。</p>
+        )}
       </div>
+
+      <aside className="space-y-8 lg:sticky lg:top-28 lg:h-fit lg:flex-none">
+        <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-neutral-900">電子書籍の紹介</h2>
+          <ul className="mt-4 space-y-2 text-sm text-neutral-600">
+            <li>・電子書籍タイトルAの紹介文が入ります。</li>
+            <li>・電子書籍タイトルBの紹介文が入ります。</li>
+          </ul>
+        </section>
+
+        <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-neutral-900">カテゴリー一覧</h2>
+          <ul className="mt-4 space-y-2 text-sm text-neutral-600">
+            <li>・カテゴリー1</li>
+            <li>・カテゴリー2</li>
+            <li>・カテゴリー3</li>
+            <li>・カテゴリー4</li>
+          </ul>
+        </section>
+
+        <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-neutral-900">人気記事ランキング</h2>
+          <ol className="mt-4 space-y-3 text-sm text-neutral-600">
+            <li>1. 人気記事タイトルサンプル</li>
+            <li>2. 人気記事タイトルサンプル</li>
+            <li>3. 人気記事タイトルサンプル</li>
+          </ol>
+        </section>
+      </aside>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center the global main content area within a 1200px container
- switch the home page layout to a responsive CSS grid that places the sidebar beside the post list on desktop and below on mobile
- keep the article list responsive with a single column on mobile and a two-column grid on wider screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caccf219bc832a9df5e16a2f391a9e