### PR TITLE
Fix post list rendering when Sanity config is missing

### DIFF
--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -73,9 +73,9 @@ export default async function CategoryPage({
     end,
   });
 
-  const posts = data?.items ?? [];
-  const total = data?.total ?? 0;
-  const catTitle = data?.catTitle ?? slug;
+  const posts = Array.isArray(data?.items) ? (data?.items as Record<string, unknown>[]) : [];
+  const total = typeof data?.total === "number" ? data.total : 0;
+  const catTitle = typeof data?.catTitle === "string" && data.catTitle ? data.catTitle : slug;
   const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ export default async function HomePage() {
     console.error("[HomePage] Failed to load posts", error);
   }
 
-  const posts = data?.items ?? [];
+  const posts = Array.isArray(data?.items) ? (data?.items as Record<string, unknown>[]) : [];
   const typedPosts = posts.filter((p): p is Record<string, unknown> => isRecord(p));
 
   return (

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,8 +1,12 @@
-import imageUrlBuilder from '@sanity/image-url'
-import type {Image} from 'sanity'
-import {client} from './sanity.client'
+import imageUrlBuilder from "@sanity/image-url";
+import type { Image } from "sanity";
+import { client, sanityConfig } from "./sanity.client";
 
-const builder = imageUrlBuilder(client)
+const builder = sanityConfig.isConfigured ? imageUrlBuilder(client) : null;
+
 export function urlFor(source: Image) {
-  return builder.image(source)
+  if (!builder) {
+    throw new Error("Sanity image builder is not configured");
+  }
+  return builder.image(source);
 }

--- a/src/lib/sanity.client.ts
+++ b/src/lib/sanity.client.ts
@@ -1,9 +1,63 @@
 // lib/sanity.client.ts
-import {createClient} from 'next-sanity'
+import { createClient } from "next-sanity";
 
-export const client = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!, // 例: "abcd1234"
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,      // 例: "production"
-  apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2025-01-01',
-  useCdn: true, // 参照クエリなので true でOK（ドラフトを見たい時は false + token）
-})
+const rawProjectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const rawDataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2025-01-01";
+const useCdn = true;
+
+const isConfigured = Boolean(rawProjectId && rawDataset);
+
+type SanityClientType = ReturnType<typeof createClient>;
+type SanityClientConfig = Parameters<typeof createClient>[0];
+
+const baseConfig: SanityClientConfig = {
+  projectId: rawProjectId ?? "",
+  dataset: rawDataset ?? "",
+  apiVersion,
+  useCdn,
+};
+
+const warnMissingConfig = (() => {
+  let warned = false;
+  return () => {
+    if (!warned && process.env.NODE_ENV !== "production") {
+      console.warn(
+        "[sanity.client] Sanity 環境変数が設定されていません。NEXT_PUBLIC_SANITY_PROJECT_ID と NEXT_PUBLIC_SANITY_DATASET を設定してください。"
+      );
+      warned = true;
+    }
+  };
+})();
+
+const fallbackClient = {
+  async fetch<T>(
+    _query: string,
+    _params?: Record<string, unknown>
+  ): Promise<T> {
+    warnMissingConfig();
+    void _query;
+    void _params;
+    return [] as unknown as T;
+  },
+  config() {
+    return baseConfig;
+  },
+  withConfig() {
+    return this as unknown as SanityClientType;
+  },
+} as unknown as SanityClientType;
+
+export const client: SanityClientType = isConfigured
+  ? createClient({
+      projectId: rawProjectId!,
+      dataset: rawDataset!,
+      apiVersion,
+      useCdn,
+    })
+  : fallbackClient;
+
+export const sanityConfig = {
+  ...baseConfig,
+  isConfigured,
+};


### PR DESCRIPTION
## Summary
- guard the Sanity client so pages still render when env vars are absent and expose the config flag
- fall back to the default image when the Sanity image builder cannot be initialised
- harden the top and category listing pages against non-array responses before rendering cards

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad2a47d84832aaa86f84e5d904dbf