### PR TITLE
Adjust home page styling to match Mamoo blog design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,16 +8,19 @@ html {
 }
 
 body {
-  background-color: #ffffff; /* gray-0 */
-  color: #111827;            /* gray-900 */
+  background: linear-gradient(180deg, #eef2ff 0%, #ffffff 45%, #ffffff 100%);
+  color: #0f172a; /* slate-900 */
+  font-feature-settings: "palt" 1;
 }
 
 /* リンク（必要最小限） */
 a {
-  color: #111827;
+  color: #0f172a;
   transition: color 0.2s ease;
 }
-a:hover { color: #4f46e5; }  /* indigo-600 */
+a:hover {
+  color: #4f46e5; /* indigo-600 */
+}
 
 /* 画像・動画は軽く角丸だけ */
 img, video { border-radius: 12px; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="bg-white text-neutral-900 antialiased">
         <SiteHeader />
         {/* max-w を外し、全幅に変更 → ページ側で自由に制御 */}
-        <main className="min-h-[60vh] px-4 py-8 sm:px-6 lg:px-8">
+        <main className="min-h-[60vh] px-0 py-8 sm:py-12">
           {children}
         </main>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,8 +46,16 @@ export default async function HomePage() {
   const typedPosts = posts.filter((p): p is Record<string, unknown> => isRecord(p));
 
   return (
-    <div className="mx-auto w-full max-w-[1200px] px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
-      <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start lg:gap-16">
+    <div className="mx-auto w-full max-w-[1200px] px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+      <header className="mb-12 flex flex-col gap-3 text-center lg:mb-14 lg:text-left">
+        <p className="text-xs font-semibold uppercase tracking-[0.4em] text-indigo-500">Mamoo Blog</p>
+        <h1 className="text-3xl font-black tracking-tight text-slate-900 sm:text-4xl">ブログ</h1>
+        <p className="text-base text-slate-600 sm:text-lg">
+          Web3、資産形成、ライフスタイルなど幅広いトピックをゆるく深掘りします。
+        </p>
+      </header>
+
+      <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start lg:gap-14">
         <section className="lg:min-w-0 lg:flex-1">
           {typedPosts.length > 0 ? (
             <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10">
@@ -61,17 +69,17 @@ export default async function HomePage() {
         </section>
 
         <aside className="space-y-8 lg:sticky lg:top-28 lg:w-[320px] lg:flex-none">
-          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">電子書籍の紹介</h2>
-            <ul className="mt-4 space-y-2 text-sm text-neutral-600">
+          <section className="rounded-3xl border border-indigo-50 bg-white/95 p-6 shadow-md shadow-indigo-100">
+            <h2 className="text-lg font-semibold text-slate-900">電子書籍の紹介</h2>
+            <ul className="mt-4 space-y-2 text-sm leading-relaxed text-slate-600">
               <li>・電子書籍タイトルAの紹介文が入ります。</li>
               <li>・電子書籍タイトルBの紹介文が入ります。</li>
             </ul>
           </section>
 
-          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">カテゴリー一覧</h2>
-            <ul className="mt-4 space-y-2 text-sm text-neutral-600">
+          <section className="rounded-3xl border border-indigo-50 bg-white/95 p-6 shadow-md shadow-indigo-100">
+            <h2 className="text-lg font-semibold text-slate-900">カテゴリー一覧</h2>
+            <ul className="mt-4 space-y-2 text-sm leading-relaxed text-slate-600">
               <li>・カテゴリー1</li>
               <li>・カテゴリー2</li>
               <li>・カテゴリー3</li>
@@ -79,9 +87,9 @@ export default async function HomePage() {
             </ul>
           </section>
 
-          <section className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">人気記事ランキング</h2>
-            <ol className="mt-4 space-y-3 text-sm text-neutral-600">
+          <section className="rounded-3xl border border-indigo-50 bg-white/95 p-6 shadow-md shadow-indigo-100">
+            <h2 className="text-lg font-semibold text-slate-900">人気記事ランキング</h2>
+            <ol className="mt-4 space-y-3 text-sm leading-relaxed text-slate-600">
               <li>1. 人気記事タイトルサンプル</li>
               <li>2. 人気記事タイトルサンプル</li>
               <li>3. 人気記事タイトルサンプル</li>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -73,14 +73,14 @@ export default function PostCard({ post }: PostCardProps) {
 
   return (
     <article
-      className="group relative flex h-full w-full flex-col overflow-hidden rounded-3xl bg-white shadow-sm shadow-slate-900/5 ring-1 ring-black/5 transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-lg hover:shadow-slate-900/10"
+      className="group relative flex h-full w-full flex-col overflow-hidden rounded-3xl border border-indigo-50 bg-white/95 shadow-md shadow-indigo-100 transition-transform duration-300 ease-out hover:-translate-y-1.5 hover:shadow-xl"
     >
       <Link
         href={href}
-        className="flex h-full flex-col focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+        className="flex h-full flex-col focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2"
       >
         {/* 画像：ワイド比率で統一し、大きめにトリミング */}
-        <div className="relative aspect-[16/10] w-full overflow-hidden bg-gradient-to-br from-indigo-100 via-white to-purple-50">
+        <div className="relative aspect-[16/10] w-full overflow-hidden bg-gradient-to-br from-indigo-100 via-white to-purple-100">
           <Image
             src={imgUrl}
             alt={title}
@@ -95,21 +95,21 @@ export default function PostCard({ post }: PostCardProps) {
         <div className="flex flex-1 flex-col p-6">
           {/* タグ */}
           {tags.length > 0 && (
-            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-indigo-500">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-500">
               {tags.join(" / ")}
             </p>
           )}
 
           {/* タイトル */}
-          <h2 className="mt-3 line-clamp-2 text-xl font-bold leading-snug text-gray-900">
+          <h2 className="mt-3 line-clamp-2 text-xl font-bold leading-snug text-slate-900">
             {title}
           </h2>
 
           {/* 日付 */}
-          {date && <time className="mt-2 block text-sm font-medium text-gray-500">{date}</time>}
+          {date && <time className="mt-2 block text-sm font-semibold text-slate-500">{date}</time>}
 
           {/* 抜粋（下端に余白を残す） */}
-          {excerpt && <p className="mt-4 line-clamp-3 text-sm leading-relaxed text-gray-600">{excerpt}</p>}
+          {excerpt && <p className="mt-4 line-clamp-3 text-sm leading-relaxed text-slate-600">{excerpt}</p>}
 
           {/* フッター余白（高さ合わせ） */}
           <div className="mt-auto pt-4" />

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -24,11 +24,15 @@ export default async function SiteHeader() {
   }
 
   return (
-    <header className="sticky top-0 z-40 border-b border-white/50 bg-white/80 backdrop-blur">
+    <header className="sticky top-0 z-40 border-b border-indigo-100/80 bg-white/90 backdrop-blur">
       <div className="mx-auto flex w-full max-w-[1200px] items-center gap-4 px-4 py-4 sm:px-6 lg:px-8">
         {/* ロゴ */}
-        <Link href="/" className="text-xl font-black tracking-tight text-neutral-900 sm:text-2xl">
-          IKEHAYA
+        <Link
+          href="/"
+          className="text-xl font-black tracking-tight text-indigo-600 transition-colors hover:text-indigo-500 sm:text-2xl"
+          aria-label="マモーブログのトップページ"
+        >
+          マモーブログ
         </Link>
 
         {/* ナビ（デスクトップ） */}
@@ -37,7 +41,7 @@ export default async function SiteHeader() {
             <Link
               key={c._id}
               href={`/category/${c.slug}`}
-              className="inline-flex items-center rounded-full px-4 py-1.5 text-sm font-medium text-neutral-600 transition-colors hover:bg-indigo-50 hover:text-indigo-600"
+              className="inline-flex items-center rounded-full px-4 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-indigo-50 hover:text-indigo-600"
             >
               {c.title}
             </Link>
@@ -46,12 +50,12 @@ export default async function SiteHeader() {
 
         {/* モバイルナビ */}
         <div className="flex flex-1 justify-end md:hidden">
-          <div className="flex max-w-[75vw] gap-2 overflow-x-auto rounded-full border border-white/60 bg-white/70 px-3 py-2 shadow-sm">
+          <div className="flex max-w-[75vw] gap-2 overflow-x-auto rounded-full border border-indigo-100 bg-white/80 px-3 py-2 shadow-sm">
             {categories.map((c) => (
               <Link
                 key={c._id}
                 href={`/category/${c.slug}`}
-                className="whitespace-nowrap rounded-full px-3 py-1 text-xs font-medium text-neutral-600 transition-colors hover:bg-indigo-50 hover:text-indigo-600"
+                className="whitespace-nowrap rounded-full px-3 py-1 text-xs font-medium text-slate-600 transition-colors hover:bg-indigo-50 hover:text-indigo-600"
               >
                 {c.title}
               </Link>


### PR DESCRIPTION
## Summary
- update the home page container, heading, and sidebar cards to mirror the requested Mamoo blog layout
- refresh post card styling with rounded corners, shadows, and hover lift animation for desktop and mobile
- rename the site header logo to "マモーブログ" and tweak the global palette and spacing for the new look

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb52e2c348832a995fbe4393fced2b