### PR TITLE
Ensure posts list shows two columns on desktop

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,12 +56,20 @@ code { padding: 0.125rem 0.25rem; border-radius: 6px; background: #f3f4f6; color
 
 /* トップページの記事グリッド（スマホ1列／PC2列） */
 .home-posts-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 2rem;
+}
+
+@media (min-width: 640px) {
+  .home-posts-grid {
+    gap: 2.5rem;
+  }
 }
 
 @media (min-width: 1024px) {
   .home-posts-grid {
-    gap: 2.5rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the top page post grid explicitly uses CSS grid columns so that desktop screens show two posts per row while mobile remains single-column

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb5f74e7f8832aa40d37e9854d6af9