### PR TITLE
feat: add homepage sidebar

### DIFF
--- a/src/components/SidebarCard.tsx
+++ b/src/components/SidebarCard.tsx
@@ -1,0 +1,18 @@
+// src/components/SidebarCard.tsx
+import type { ReactNode } from "react";
+
+export type SidebarCardProps = {
+  title: string;
+  children: ReactNode;
+};
+
+export default function SidebarCard({ title, children }: SidebarCardProps) {
+  return (
+    <section
+      className="group rounded-3xl border border-indigo-50 bg-white/95 p-6 shadow-md shadow-indigo-100 transition-transform duration-300 ease-out hover:-translate-y-1.5 hover:shadow-xl"
+    >
+      <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+      <div className="mt-4 text-sm leading-relaxed text-slate-600">{children}</div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable SidebarCard component that mirrors the existing card styling
- extend the home page layout with ebook, category, and ranking sections backed by post data with safe fallbacks
- keep the post grid responsive while rendering ranked links for popular posts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb620e404c832abc074f3cf78e6873