### PR TITLE
Adjust homepage layout spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,13 @@ code { padding: 0.125rem 0.25rem; border-radius: 6px; background: #f3f4f6; color
   }
 }
 
+@media (min-width: 1536px) {
+  .home-posts-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 3rem;
+  }
+}
+
 .home-layout {
   display: flex;
   flex-direction: column;
@@ -85,6 +92,20 @@ code { padding: 0.125rem 0.25rem; border-radius: 6px; background: #f3f4f6; color
     grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
     gap: 3rem;
     align-items: start;
+  }
+}
+
+@media (min-width: 1280px) {
+  .home-layout {
+    grid-template-columns: minmax(0, 1.4fr) minmax(280px, 340px);
+    gap: 3.5rem;
+  }
+}
+
+@media (min-width: 1536px) {
+  .home-layout {
+    grid-template-columns: minmax(0, 1.6fr) minmax(300px, 360px);
+    gap: 4rem;
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -199,7 +199,7 @@ export default async function HomePage() {
     "group rounded-3xl border border-indigo-50 bg-white/95 p-6 shadow-md shadow-indigo-100 transition-transform duration-300 ease-out hover:-translate-y-1.5 hover:shadow-xl";
 
   const containerClasses =
-    "mx-auto w-full max-w-[1200px] px-4 py-12 sm:px-6 lg:px-8 lg:py-16";
+    "mx-auto w-full max-w-[1200px] px-4 py-12 sm:px-6 lg:px-8 lg:py-16 xl:max-w-[1360px] xl:px-10 2xl:max-w-[1520px] 2xl:px-12";
   const layoutClasses = "home-layout";
   const postsGridClasses = "home-posts-grid grid grid-cols-1 gap-8 sm:gap-10 lg:grid-cols-2";
 


### PR DESCRIPTION
## Summary
- widen the homepage container on large screens to avoid the layout feeling overly centered
- tweak the grid ratios so the post list takes more horizontal space next to the sidebar
- allow a third post column on very wide screens for better balance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb6c563544832a89e7a55c19ea93db